### PR TITLE
fix(ci): gitleaks range scan falls back to full scan when base SHA is unreachable

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -546,7 +546,7 @@ jobs:
           set -euo pipefail
           GITLEAKS_VERSION="8.24.3"
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar xz gitleaks -C /tmp
+            | tar -xzf - -C /tmp gitleaks
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -556,17 +556,20 @@ jobs:
             HEAD="${{ github.sha }}"
           fi
 
-          SCAN_ARGS=""
+          # Use a bash array so the --log-opts value (which contains spaces) is
+          # passed as a single argument to gitleaks — unquoted string expansion
+          # would cause word-splitting and make --first-parent an unknown flag.
+          SCAN_ARGS=()
           if [ -n "$BASE" ] \
              && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
              && git cat-file -t "$BASE" >/dev/null 2>&1; then
-            SCAN_ARGS="--log-opts=--no-merges --first-parent ${BASE}..${HEAD}"
+            SCAN_ARGS=(--log-opts "--no-merges --first-parent ${BASE}..${HEAD}")
             echo "Range scan: ${BASE}..${HEAD}"
           else
             echo "Base SHA not available — scanning full repository"
           fi
 
-          /tmp/gitleaks detect --redact -v --exit-code=1 $SCAN_ARGS
+          /tmp/gitleaks detect --redact -v --exit-code=1 "${SCAN_ARGS[@]}"
 
   security-licenses:
     name: RuneGate/Security/LicenseCompliance

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -542,9 +542,31 @@ jobs:
         with:
           fetch-depth: 0
       - name: gitleaks — hardcoded credential detection (IEC 62443 4-1 ML4 SM-8)
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION="8.24.3"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar xz gitleaks -C /tmp
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          SCAN_ARGS=""
+          if [ -n "$BASE" ] \
+             && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
+             && git cat-file -t "$BASE" >/dev/null 2>&1; then
+            SCAN_ARGS="--log-opts=--no-merges --first-parent ${BASE}..${HEAD}"
+            echo "Range scan: ${BASE}..${HEAD}"
+          else
+            echo "Base SHA not available — scanning full repository"
+          fi
+
+          /tmp/gitleaks detect --redact -v --exit-code=1 $SCAN_ARGS
 
   security-licenses:
     name: RuneGate/Security/LicenseCompliance


### PR DESCRIPTION
Closes #3

Replaces `gitleaks/gitleaks-action@v2` with a direct gitleaks install. When the push base SHA (`github.event.before`) is missing from git history (e.g. after squash-merge on a new repo), falls back to a full-repo scan. Equivalent ML4 SM-8 coverage, robust to orphaned SHAs.