### PR TITLE
ci: fix quality-gates for rune-ui and optimize Docker builds

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -219,7 +219,7 @@ jobs:
           push: false
           tags: rune-ui:rune-ci-local
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
+          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max' || '' }}
       - run: |
           set -euo pipefail
           docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune-ui:rune-ci-local
@@ -271,8 +271,8 @@ jobs:
           load: true
           tags: rune-ui:rune-ci-local
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
-      - name: Generate SBOMs — CycloneDX via Syft (IEC 62443 4-1 ML4 SM-9)
+          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max' || '' }}
+      - name: Generate SBOMs
         run: |
           set -euo pipefail
           mkdir -p sbom

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -180,6 +180,9 @@ jobs:
     needs: [changes, security-secrets]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -199,19 +202,14 @@ jobs:
           pip install --upgrade pip
           pip install --prefer-binary -r requirements.txt pytest
       - run: .venv/bin/python -m pytest -p no:cov -o addopts='' tests/ -v --tb=short
-      - uses: docker/setup-qemu-action@v4
+
       - uses: docker/setup-buildx-action@v4
-      - name: Build multi-arch (amd64 + arm64)
-        uses: docker/build-push-action@v7
+      - uses: docker/login-action@v3
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: rune:rune-ci-local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Load amd64 image and smoke test
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build amd64 image and smoke test
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -219,11 +217,12 @@ jobs:
           platforms: linux/amd64
           load: true
           push: false
-          tags: rune:rune-ci-local
-          cache-from: type=gha
+          tags: rune-ui:rune-ci-local
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
       - run: |
           set -euo pipefail
-          docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune:rune-ci-local
+          docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune-ui:rune-ci-local
           trap 'echo "=== rune-smoke container logs ==="; docker logs rune-smoke 2>&1 | tail -200 || true; docker rm -f rune-smoke >/dev/null 2>&1 || true' EXIT
           ready=0
           for i in {1..60}; do
@@ -254,9 +253,15 @@ jobs:
       id-token: write      # required for SLSA provenance attestation
       attestations: write  # required for SLSA provenance attestation
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
         uses: docker/build-push-action@v7
         with:
@@ -264,19 +269,19 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           load: true
-          tags: rune:rune-ci-local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: rune-ui:rune-ci-local
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
       - name: Generate SBOMs — CycloneDX via Syft (IEC 62443 4-1 ML4 SM-9)
         run: |
           set -euo pipefail
           mkdir -p sbom
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${PWD}:/work" anchore/syft:v1.17.0 rune:rune-ci-local -o cyclonedx-json=/work/sbom/rune-image.cdx.json
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "${PWD}:/work" anchore/syft:v1.17.0 rune-ui:rune-ci-local -o cyclonedx-json=/work/sbom/rune-ui-image.cdx.json
       - name: Scan SBOMs — Grype + Trivy (IEC 62443 4-1 ML4 SVV-3 / DM-4)
         run: |
           set -euo pipefail
-          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 -c /work/.grype.yaml sbom:/work/sbom/rune-image.cdx.json -o json > sbom/rune-grype.json
-          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-image.cdx.json --format json --output /work/sbom/rune-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 -c /work/.grype.yaml sbom:/work/sbom/rune-ui-image.cdx.json -o json > sbom/rune-ui-grype.json
+          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-ui-image.cdx.json --format json --output /work/sbom/rune-ui-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
       - name: Enforce CVE policy — IEC 62443 4-1 ML4 DM-4
         env:
           BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
@@ -348,7 +353,7 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            sbom/rune-image.cdx.json
+            sbom/rune-ui-image.cdx.json
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -575,8 +580,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- **Fix broken workflow** copied from rune/ with wrong references:
  - Lint `app/` instead of nonexistent `rune/rune_bench` directories
  - Test `tests/` instead of nonexistent `test_cli_http_mode`/`test_api_server`
  - SAST scans `app/` instead of nonexistent `rune/rune_bench`
  - **Critical**: publish to `ghcr.io/lpasquali/rune-ui` (was overwriting rune images!)
  - Clear rune-specific CVE vendor constraints
- **Remove inapplicable jobs**: regression-python, integration-ollama, bare-install-smoke
- **Docker optimization**: switch from GHA cache to GHCR registry cache, remove redundant QEMU multi-arch from smoke
- **Fix SBOM artifacts**: rename from `rune-*` to `rune-ui-*`

## Expected impact
- Correct image publishing (stops overwriting rune images)
- Remove ~5-8 min of irrelevant CI jobs
- Registry cache enables cross-job sharing

## Test plan
- [ ] CI passes — all remaining quality gates green
- [ ] Image publishes to correct `ghcr.io/lpasquali/rune-ui` registry
- [ ] SBOM artifacts named correctly

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)