### PR TITLE
fix(ci): correct publish step name in quality-gates.yml

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -568,7 +568,7 @@ jobs:
           IMAGE_TAG="${REF_SLUG}-${GITHUB_SHA::7}"
           echo "image_name=ghcr.io/lpasquali/rune-ui" >> "$GITHUB_OUTPUT"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Build and push rune image
+      - name: Build and push rune-ui image
         uses: docker/build-push-action@v7
         with:
           context: .


### PR DESCRIPTION
Fix remaining copy-paste artifact from rune: rename publish step from 'Build and push rune image' to 'Build and push rune-ui image'.

Closes #6