### PR TITLE
ci: build image once, GHCR cache, parallel native arm64 release

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -197,7 +197,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64
           cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max
@@ -205,11 +205,11 @@ jobs:
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
     needs: [changes, security-secrets, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -267,13 +267,13 @@ jobs:
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       id-token: write      # required for SLSA provenance attestation
       attestations: write  # required for SLSA provenance attestation
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -187,6 +187,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -198,9 +199,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           tags: ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max' || '' }}
 
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -560,12 +560,7 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
       - changes
-      - build-image
-      - smoke-cli-api
-      - security-sbom
-      - security-sast
-      - security-secrets
-      - security-licenses
+      - merge-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -642,7 +637,6 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
-      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all concept gates passed

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -192,17 +192,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push amd64 temp image
+      - name: Build and push amd64 temp image (same-repo)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          push: true
+          load: false
           tags: ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max' || '' }}
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max
+      - name: Build amd64 temp image (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
 
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
@@ -232,7 +243,6 @@ jobs:
           pip install --prefer-binary -r requirements.txt pytest
       - run: .venv/bin/python -m pytest -p no:cov -o addopts='' tests/ -v --tb=short
 
-      - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -175,9 +175,36 @@ jobs:
   # Decoupled from the Python test chain so a Dockerfile-only change still
   # exercises the smoke and SBOM jobs without re-running Python unit tests.
 
+  build-image:
+    name: RuneGate/Build/Docker-Image-amd64
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push amd64 temp image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max
+
   smoke-cli-api:
     name: RuneGate/CLI-and-API-Smoke/Python+Containers
-    needs: [changes, security-secrets]
+    needs: [changes, security-secrets, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -209,17 +236,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build amd64 image and smoke test
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          push: false
-          tags: rune-ui:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max' || '' }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64 rune-ui:rune-ci-local
       - run: |
           set -euo pipefail
           docker run -d --name rune-smoke -e RUNE_API_AUTH_DISABLED=1 -p 18080:8080 rune-ui:rune-ci-local
@@ -246,7 +266,7 @@ jobs:
 
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
-    needs: [changes]
+    needs: [changes, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -256,22 +276,15 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: rune-ui:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max' || '' }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-ui:ci-${{ github.sha }}-amd64 rune-ui:rune-ci-local
       - name: Generate SBOMs
         run: |
           set -euo pipefail
@@ -280,8 +293,8 @@ jobs:
       - name: Scan SBOMs — Grype + Trivy (IEC 62443 4-1 ML4 SVV-3 / DM-4)
         run: |
           set -euo pipefail
-          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 -c /work/.grype.yaml sbom:/work/sbom/rune-ui-image.cdx.json --vex /work/.vex/permanent.openvex.json -o json > sbom/rune-ui-grype.json
-          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-ui-image.cdx.json --vex /work/.vex/permanent.openvex.json --format json --output /work/sbom/rune-ui-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 -c /work/.grype.yaml sbom:/work/sbom/rune-ui-image.cdx.json -o json > sbom/rune-ui-grype.json
+          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-ui-image.cdx.json --format json --output /work/sbom/rune-ui-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
       - name: Enforce CVE policy — IEC 62443 4-1 ML4 DM-4
         env:
           BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
@@ -547,7 +560,12 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
       - changes
-      - merge-gate
+      - build-image
+      - smoke-cli-api
+      - security-sbom
+      - security-sast
+      - security-secrets
+      - security-licenses
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -568,16 +586,22 @@ jobs:
           IMAGE_TAG="${REF_SLUG}-${GITHUB_SHA::7}"
           echo "image_name=ghcr.io/lpasquali/rune-ui" >> "$GITHUB_OUTPUT"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Build and push rune-ui image
+      - name: Build and push arm64 temp image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache,mode=max
+          tags: ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-arm64
+          cache-from: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache-arm64,mode=max
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }} \
+            ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-amd64 \
+            ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-arm64
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}
@@ -612,11 +636,13 @@ jobs:
       - coverage-python
       - feature-python
       - linting-python
+      - build-image
       - smoke-cli-api
       - security-sbom
       - security-sast
       - security-secrets
       - security-licenses
+      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all concept gates passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,27 @@ permissions:
   contents: read
 
 jobs:
+  verify-tag:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            echo "Tags must only be pushed AFTER merging to main." >&2
+            exit 1
+          fi
+
   build-amd64:
     name: Build image (amd64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
@@ -22,15 +41,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Verify tag is on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
-            echo "Tags must only be pushed AFTER merging to main." >&2
-            exit 1
-          fi
 
       - uses: docker/setup-buildx-action@v4
 
@@ -54,6 +64,7 @@ jobs:
 
   build-arm64:
     name: Build image (arm64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,3 @@
-# Release rune-ui on version tags.
-#
-# Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
-#
-# ─── TAGGING PROCESS ────────────────────────────────────────────────────────
-#  Tags MUST only be pushed AFTER the PR has been merged to main and all
-#  quality gates (RuneGate Grouped) have passed.
-#
-#  Correct flow:
-#    1. Open PR → quality gates pass → merge to main
-#    2. git pull origin main
-#    3. git tag v<version>
-#    4. git push origin v<version>
-# ────────────────────────────────────────────────────────────────────────────
-
 name: Release
 
 on:
@@ -24,13 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Build image and create GitHub Release
+  build-amd64:
+    name: Build image (amd64)
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # Required to create GitHub Releases
-      packages: write   # Required to push to GHCR
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -47,7 +32,6 @@ jobs:
             exit 1
           fi
 
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
@@ -57,16 +41,79 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push UI image
+      - name: Build and push amd64 image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/lpasquali/rune-ui:${{ github.ref_name }}
-            ghcr.io/lpasquali/rune-ui:latest
+          tags: ghcr.io/lpasquali/rune-ui:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-amd64,mode=max
+
+  build-arm64:
+    name: Build image (arm64)
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/lpasquali/rune-ui:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-ui:buildcache-arm64,mode=max
+
+  merge-manifest:
+    name: Create multi-arch manifest and GitHub Release
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required to create GitHub Releases
+      packages: write   # Required to push to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/lpasquali/rune-ui:${{ github.ref_name }} \
+            --tag ghcr.io/lpasquali/rune-ui:latest \
+            ghcr.io/lpasquali/rune-ui:${{ github.ref_name }}-amd64 \
+            ghcr.io/lpasquali/rune-ui:${{ github.ref_name }}-arm64
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Verify tag is on main
         run: |
           git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+          # Dereference annotated tags to their commit SHA before the ancestry check.
+          COMMIT_SHA=$(git rev-parse "${GITHUB_SHA}^{commit}" 2>/dev/null || echo "$GITHUB_SHA")
+          if ! git merge-base --is-ancestor "$COMMIT_SHA" origin/main; then
             echo "ERROR: Tagged commit is not reachable from origin/main." >&2
             echo "Tags must only be pushed AFTER merging to main." >&2
             exit 1


### PR DESCRIPTION
## Changes

### Build image once per pipeline (#30)
- New `build-image` job; smoke/sbom pull pre-built image

### GHCR registry cache (#32)
- Always-on GHCR cache (removed conditional empty `cache-to` on PRs)

### Parallel native arm64 release (#33)
- `build-amd64` + `build-arm64` + `merge-manifest` in release.yml

Closes #30
Closes #32
Closes #33