### PR TITLE
fix(ci): gate Docker push on full Merge Gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -544,14 +544,10 @@ jobs:
 
   publish-image-and-notify-charts:
     name: RuneGate/CD/Publish-Image-and-Notify-Charts
-    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true' && needs.merge-gate.result == 'success'
     needs:
       - changes
-      - smoke-cli-api
-      - security-sbom
-      - security-sast
-      - security-secrets
-      - security-licenses
+      - merge-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -621,7 +617,6 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
-      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all concept gates passed

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -544,7 +544,7 @@ jobs:
 
   publish-image-and-notify-charts:
     name: RuneGate/CD/Publish-Image-and-Notify-Charts
-    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true' && needs.merge-gate.result == 'success'
+    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
       - changes
       - merge-gate


### PR DESCRIPTION
## Summary

- `publish-image-and-notify-charts` previously only waited on docker-track security jobs before pushing to GHCR — tests, coverage, and linting could all be failing without blocking the image push
- Restructured so publish depends on `merge-gate`, which already aggregates every quality job
- Removed `publish-image-and-notify-charts` from `merge-gate`'s `needs:` to break the circular dependency

New chain: `[all quality jobs] → merge-gate → publish-image-and-notify-charts`

Closes #16

## Test plan

- [ ] Push a commit touching `app/` with a failing test → verify `merge-gate` fails and `RuneGate/CD/Publish-Image-and-Notify-Charts` is skipped (no image pushed)
- [ ] Push a clean commit → verify `merge-gate` passes and image is pushed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)