### PR TITLE
fix(ci): correct Merge Gate success message to reflect skipped-job policy

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -659,13 +659,16 @@ jobs:
           python3 - <<'PY'
           import json, os, sys
           data = json.loads(os.environ['NEEDS_JSON'])
-          failed = [(k, v.get('result')) for k, v in data.items() if v.get('result') not in ('success', 'skipped')]
-          for k, v in data.items():
-              print(f'{k}: {v.get("result")}')
+          results = {k: v.get('result') for k, v in data.items()}
+          failed = [(k, r) for k, r in results.items() if r not in ('success', 'skipped')]
+          passed = [k for k, r in results.items() if r == 'success']
+          skipped = [k for k, r in results.items() if r == 'skipped']
+          for k, r in sorted(results.items()):
+              print(f'{k}: {r}')
           if failed:
               print('Merge blocked due to failing RuneGate checks:')
               for name, result in failed:
                   print(f'  - {name}: {result}')
               sys.exit(1)
-          print('All RuneGate checks passed.')
+          print(f'Merge Gate OK — {len(passed)} passed, {len(skipped)} skipped (skipped jobs treated as acceptable).')
           PY


### PR DESCRIPTION
## Summary

- The Merge Gate step accepted both `success` and `skipped` results but logged "All RuneGate checks passed." which is misleading when some jobs were skipped due to path filtering.
- Updated the success message to report exact counts of passed and skipped jobs, e.g. `Merge Gate OK — 7 passed, 3 skipped (skipped jobs treated as acceptable).`
- This addresses the unresolved review finding from PR #25, which was merged via admin bypass.

## IEC 62443 ML4 traceability

PR #25 was merged with an admin bypass and one review finding left unresolved. This PR resolves that finding and restores full traceability per IEC 62443 4-1 ML4 requirements.

## Test plan

- [ ] CI passes on this PR (the workflow change is self-testing via the Merge Gate step)
- [ ] Verify the Merge Gate step output shows the new message format with pass/skip counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)