### PR TITLE
[Legal] Fix LICENSE copyright placeholder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -184,7 +184,7 @@
       comment syntax for the file format. Please also get an approval
       from the project maintainer(s) before applying the license.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025-2026 The Rune Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
References lpasquali/rune-operator#32

## Summary
- Replace Apache-2.0 boilerplate copyright placeholder `[yyyy] [name of copyright owner]` with `2025-2026 The Rune Authors`

## DoD Level
Level 3 — text-only change, no code impact

## Acceptance Criteria Evidence
```
$ grep "\[yyyy\]" LICENSE
(no output — 0 matches)

$ grep "2025-2026 The Rune Authors" LICENSE
   Copyright 2025-2026 The Rune Authors
```

## Audit Checks
No triggers fired — LICENSE text change only, no code or config modifications.

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)