### PR TITLE
[Legal] Add NOTICE file (Apache-2.0 Section 4(d))

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,32 @@
+RUNE UI
+Copyright 2025-2026 The Rune Authors
+
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by third parties.
+
+---
+
+FastAPI (https://github.com/tiangolo/fastapi)
+  License: MIT
+  Copyright (c) Sebastián Ramírez
+
+Uvicorn (https://github.com/encode/uvicorn)
+  License: BSD-3-Clause
+  Copyright (c) Encode OSS Ltd.
+
+Jinja2 (https://github.com/pallets/jinja)
+  License: BSD-3-Clause
+  Copyright (c) Armin Ronacher / Pallets
+
+HTTPX (https://github.com/encode/httpx)
+  License: BSD-3-Clause
+  Copyright (c) Encode OSS Ltd.
+
+python-dotenv (https://github.com/theskumar/python-dotenv)
+  License: BSD-3-Clause
+  Copyright (c) Saurabh Kumar
+
+python-multipart (https://github.com/andrew-d/python-multipart)
+  License: Apache-2.0
+  Copyright (c) Andrew Dunham


### PR DESCRIPTION
## Summary

- Adds NOTICE file with copyright attribution and third-party dependency notices (FastAPI, Uvicorn, Jinja2, HTTPX, python-dotenv, python-multipart) as required by Apache License 2.0 Section 4(d)

Closes #42
Part of lpasquali/rune#133

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- NOTICE file exists at repo root
- Contains Copyright 2025-2026 The Rune Authors
- Third-party dependencies attributed with license info

## Audit Checks

No triggers fired. Legal metadata file only.

## Breaking Changes

None.