### PR TITLE
Add GitHub process enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Something isn't working
+labels: ["type/bug", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill in all required fields.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How critical is this bug?
+      options:
+        - "p0 — blocks release or security exposure"
+        - "p1 — must fix in current milestone"
+        - "p2 — planned, not time-sensitive"
+        - "p3 — low priority"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system is affected?
+      options:
+        - "area/core"
+        - "area/api"
+        - "area/agents"
+        - "area/ci-cd"
+        - "area/helm"
+        - "area/operator"
+        - "area/ui"
+        - "area/docs"
+        - "area/security"
+        - "area/compliance"
+        - "area/infra"
+        - "area/observability"
+    validations:
+      required: true
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent Epic
+      description: "Every issue must belong to an epic. Paste the epic issue URL or #number. If no epic exists yet, create one first."
+      placeholder: "#NNN or https://github.com/lpasquali/repo/issues/NNN"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Exact commands or steps to reproduce the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "OS, Python/Go version, Docker version, Helm version, cluster type (kind/production), etc."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste error output, stack traces, or attach screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/lpasquali/rune-docs
+    about: "Read the docs before opening an issue — your question may already be answered."

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,84 @@
+name: Epic
+description: Parent issue tracking a body of work (like an agile swim lane)
+labels: ["type/epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics group related issues into a trackable work stream. Every issue in this project must belong to an epic.
+        Epics serve as swim lanes — they represent parallel streams of work that can be planned, tracked, and prioritized independently.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - "p0 — blocks release or security exposure"
+        - "p1 — must fix in current milestone"
+        - "p2 — planned, not time-sensitive"
+        - "p3 — low priority"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - "area/core"
+        - "area/api"
+        - "area/agents"
+        - "area/ci-cd"
+        - "area/helm"
+        - "area/operator"
+        - "area/ui"
+        - "area/docs"
+        - "area/security"
+        - "area/compliance"
+        - "area/infra"
+        - "area/observability"
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: "One sentence: what does 'done' look like for this epic?"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this epic exist? What problem does it solve? What milestone does it belong to?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which repos and components are affected?
+    validations:
+      required: true
+  - type: textarea
+    id: child_issues
+    attributes:
+      label: Child issues
+      description: "Checklist of issues that must be completed to close this epic. Add issues as they are created."
+      value: |
+        - [ ] #
+        - [ ] #
+    validations:
+      required: true
+  - type: textarea
+    id: exit_criteria
+    attributes:
+      label: Exit criteria
+      description: "Concrete, testable conditions that close the epic — beyond just 'all child issues done'."
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and dependencies
+      description: "Blockers, external dependencies, cross-epic dependencies, licensing or security concerns."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,101 @@
+name: Feature Request
+description: New feature or improvement
+labels: ["type/enhancement", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide enough detail for this issue to be implementable by any developer or agent.
+        Refer to [SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md) for DoD levels and audit requirements.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - "p0 — blocks release or security exposure"
+        - "p1 — must fix in current milestone"
+        - "p2 — planned, not time-sensitive"
+        - "p3 — low priority"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - "area/core"
+        - "area/api"
+        - "area/agents"
+        - "area/ci-cd"
+        - "area/helm"
+        - "area/operator"
+        - "area/ui"
+        - "area/docs"
+        - "area/security"
+        - "area/compliance"
+        - "area/infra"
+        - "area/observability"
+    validations:
+      required: true
+  - type: dropdown
+    id: dod_level
+    attributes:
+      label: DoD Level
+      description: "Which Definition of Done level applies? See SYSTEM_PROMPT.md."
+      options:
+        - "Level 1 — Full Validation (runtime, API, Helm, Dockerfile changes)"
+        - "Level 2 — Test Infrastructure (test config, CI, coverage, linter only)"
+        - "Level 3 — Documentation (Markdown, MkDocs, diagrams only)"
+    validations:
+      required: true
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent Epic
+      description: "Every issue must belong to an epic. Paste the epic issue URL or #number. If no epic exists yet, create one first."
+      placeholder: "#NNN or https://github.com/lpasquali/repo/issues/NNN"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: Numbered list of what must be implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation_notes
+    attributes:
+      label: Implementation notes
+      description: "File paths, function names, architectural decisions, relevant ADRs."
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: "Checkboxes. Each must have evidence in the PR. Include any required audit checks (legal check, cyber check) per the trigger table in SYSTEM_PROMPT.md."
+      value: |
+        - [ ]
+        - [ ]
+        - [ ] `legal check:*` (if applicable — specify which)
+        - [ ] `cyber check:*` (if applicable — specify which)
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan evidence required
+      description: "What evidence must be attached to the PR beyond CI? Screenshots, log snippets, before/after diffs."
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,78 @@
+## Summary
+
+<!-- 1-3 sentences: what and why -->
+
+Closes #<!-- issue number -->
+Epic: #<!-- parent epic number -->
+
+## DoD Level
+
+<!-- Check ONE. See https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md -->
+
+- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
+- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
+- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)
+
+## Level 1 Checklist
+
+<!-- Skip this section if Level 2 or 3. All boxes must be checked for Level 1. -->
+
+- [ ] Tested in **docker-compose mode**
+- [ ] Tested in **kind (Kubernetes) mode**
+- [ ] Tested in **standalone CLI mode**
+- [ ] **Breaking change audit**: API versions, persistent data, cross-component contracts
+- [ ] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs
+
+## Level 2 Checklist
+
+<!-- Skip if Level 1 or 3. -->
+
+- [ ] Full test suite passes
+- [ ] Coverage not degraded (at or above floor)
+- [ ] No unintended CI side effects
+
+## Level 3 Checklist
+
+<!-- Skip if Level 1 or 2. -->
+
+- [ ] `mkdocs build --strict` passes
+- [ ] `pymarkdown scan README.md docs` passes
+
+## Audit Checks
+
+<!-- Required when trigger conditions are met. See trigger table in SYSTEM_PROMPT.md. -->
+<!-- Delete rows that don't apply. If none apply, write "No triggers fired." -->
+
+| Check | Result | Evidence |
+|---|---|---|
+| `legal check:dep <pkg>` | PASS / FAIL | <!-- link or paste --> |
+| `legal check:integration <agent>` | PASS / FAIL | <!-- link or paste --> |
+| `legal check:tool <tool>` | PASS / FAIL | <!-- link or paste --> |
+| `cyber check:dep <pkg>` | PASS / FAIL | <!-- link or paste --> |
+| `cyber check:api` | PASS / FAIL | <!-- link or paste --> |
+| `cyber check:supply-chain` | PASS / FAIL | <!-- link or paste --> |
+| `cyber check:vex` | PASS / FAIL | <!-- link or paste --> |
+
+## Acceptance Criteria Evidence
+
+<!-- For each acceptance criterion from the issue, tick the box and attach evidence. -->
+<!-- CI-produced evidence (green checks) counts automatically. -->
+<!-- For everything else: screenshots, log snippets, before/after diffs, command output. -->
+
+- [ ] <!-- criterion 1 — evidence: ... -->
+- [ ] <!-- criterion 2 — evidence: ... -->
+
+## Test Plan Evidence
+
+<!-- Attach required evidence per the issue's test plan section. -->
+
+- [ ] <!-- evidence item 1 -->
+- [ ] <!-- evidence item 2 -->
+
+## Breaking Changes
+
+<!-- Describe any backward-incompatible changes. If none, write "None." -->
+
+## Notes for Reviewer
+
+<!-- Anything the reviewer should know: edge cases, decisions made, open questions. -->

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -621,6 +621,55 @@ jobs:
           }
           JSON
 
+  # ─── Process: PR body compliance ─────────────────────────────────────────────
+
+  pr-body-check:
+    name: RuneGate/Process/PR-Body-Compliance
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body structure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const body = pr.data.body || '';
+            const errors = [];
+            if (!/[Cc]loses?\s+#\d+|[Ff]ixes?\s+#\d+|[Rr]esolves?\s+#\d+/.test(body)) {
+              errors.push('PR must reference an issue (Closes #NNN, Fixes #NNN, or Resolves #NNN)');
+            }
+            if (!/\[x\]\s+\*\*Level\s+[123]/.test(body)) {
+              errors.push('PR must check exactly one DoD level (Level 1, 2, or 3)');
+            }
+            if (!/## Acceptance Criteria Evidence/.test(body)) {
+              errors.push('PR must include "## Acceptance Criteria Evidence" section');
+            }
+            if (!/## Audit Checks/.test(body)) {
+              errors.push('PR must include "## Audit Checks" section');
+            }
+            if (/## Audit Checks/.test(body) && !/PASS|FAIL|No triggers fired/.test(body)) {
+              errors.push('Audit Checks section must report PASS/FAIL results or state "No triggers fired"');
+            }
+            if (/\|\s*FAIL\s*\|/.test(body)) {
+              errors.push('PR has FAIL audit check results — resolve before merging');
+            }
+            if (!/## Breaking Changes/.test(body)) {
+              errors.push('PR must include "## Breaking Changes" section');
+            }
+            if (errors.length > 0) {
+              const msg = '**PR Body Compliance Check Failed**\n\n' +
+                errors.map(e => `- ❌ ${e}`).join('\n') +
+                '\n\nRefer to the PR template and SYSTEM_PROMPT.md for requirements.';
+              core.setFailed(msg);
+              console.log(msg);
+            } else {
+              console.log('PR body compliance check passed.');
+            }
+
   # ─── Merge gate ──────────────────────────────────────────────────────────────
 
   merge-gate:
@@ -637,6 +686,7 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
+      - pr-body-check
     runs-on: ubuntu-latest
     steps:
       - name: Verify all gates passed or were skipped


### PR DESCRIPTION
## Summary

Adds standardized GitHub issue templates (bug, feature, epic), PR template, and `pr-body-check` CI job from rune-docs to enforce process compliance across the RUNE platform.

Closes #32
Epic: #30

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Acceptance Criteria Evidence

- [x] Issue templates (bug.yml, feature.yml, epic.yml, config.yml) added to `.github/ISSUE_TEMPLATE/`
- [x] PR template added to `.github/PULL_REQUEST_TEMPLATE.md`
- [x] `pr-body-check` job added to `quality-gates.yml` and wired into merge-gate
- [x] All YAML files pass `yaml.safe_load()` validation

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:supply-chain` | PASS | CI workflow modified — pr-body-check job added; no new external actions beyond existing actions/github-script@v7 |

## Breaking Changes

None.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>