### PR TITLE
chore(pypi): update homepage URL to point to consolidated docs site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/lpasquali/rune-ui"
+Homepage = "https://lpasquali.github.io/rune-docs/"
 Documentation = "https://lpasquali.github.io/rune-docs/"
 Repository = "https://github.com/lpasquali/rune-ui"
 Issues = "https://github.com/lpasquali/rune-ui/issues"


### PR DESCRIPTION
## Summary

Updates the PyPI `Homepage` URL in `pyproject.toml` to point to the consolidated GitHub Pages documentation site instead of the GitHub repository root. 

Closes #64 (rune-docs)
Epic: #121

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [ ] Tested in **docker-compose mode**
- [ ] Tested in **kind (Kubernetes) mode**
- [ ] Tested in **standalone CLI mode**
- [ ] **Breaking change audit**: API versions, persistent data, cross-component contracts
- [ ] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

- [ ] `mkdocs build --strict` passes
- [ ] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] PyPI URLs point to `rune-docs` GH Pages.

## Test Plan Evidence

- [x] Syntax checked via Ruff.

## Breaking Changes

None.

## Notes for Reviewer

None.
