### PR TITLE
fix: healthz endpoint, estimation crash, API status resilience

### DIFF
--- a/rune_ui/api_client.py
+++ b/rune_ui/api_client.py
@@ -19,6 +19,7 @@ class RuneApiClient:
     async def get_health(self) -> Dict[str, Any]:
         async with httpx.AsyncClient() as client:
             response = await client.get(f"{self.base_url}/healthz")
+            response.raise_for_status()
             return dict(response.json())
 
     async def get_vastai_models(self) -> Dict[str, Any]:
@@ -37,6 +38,7 @@ class RuneApiClient:
                 headers=self.headers,
                 json=payload,
             )
+            response.raise_for_status()
             return dict(response.json())
 
     async def submit_job(self, kind: str, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/rune_ui/main.py
+++ b/rune_ui/main.py
@@ -90,6 +90,12 @@ async def stream_job_logs(request: Request, job_id: str) -> StreamingResponse:
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
+@app.get("/healthz")
+async def healthz() -> JSONResponse:
+    """Liveness probe for Docker/K8s health checks."""
+    return JSONResponse({"status": "ok"})
+
+
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> Any:
     return templates.TemplateResponse(request, "base.html")
@@ -101,9 +107,9 @@ async def get_status(request: Request) -> str:
         health = await api_client.get_health()
         if health.get("status") == "ok":
             return '<span style="color: var(--green)">API STATUS: ONLINE</span>'
-        return '<span style="color: var(--red)">API STATUS: DEGRADED</span>'
+        return '<span style="color: var(--yellow)">API STATUS: NOT CONNECTED</span>'
     except Exception:
-        return '<span style="color: var(--red)">API STATUS: OFFLINE</span>'
+        return '<span style="color: var(--yellow)">API STATUS: NOT CONNECTED</span>'
 
 
 @app.get("/benchmarks", response_class=HTMLResponse)

--- a/rune_ui/templates/estimate_modal.html
+++ b/rune_ui/templates/estimate_modal.html
@@ -3,16 +3,16 @@
     <h2 style="color: var(--orange)">PRE-FLIGHT SPEND ALERT</h2>
     
     <div class="card" style="margin-bottom: 20px; border-color: var(--yellow)">
-        <p><strong>Projected Cost:</strong> <span style="font-size: 1.5em; color: var(--green)">${{ estimate.projected_cost_usd }}</span></p>
-        <p><strong>Cost Driver:</strong> {{ estimate.cost_driver.upper() }}</p>
-        <p><strong>Resource Impact:</strong> {{ estimate.resource_impact.upper() }}</p>
-        
-        {% if estimate.local_energy_kwh > 0 %}
-        <p><strong>Energy consumption:</strong> {{ estimate.local_energy_kwh }} kWh</p>
+        <p><strong>Projected Cost:</strong> <span style="font-size: 1.5em; color: var(--green)">${{ estimate['projected_cost_usd'] }}</span></p>
+        <p><strong>Cost Driver:</strong> {{ estimate['cost_driver']|upper }}</p>
+        <p><strong>Resource Impact:</strong> {{ estimate['resource_impact']|upper }}</p>
+
+        {% if estimate.get('local_energy_kwh', 0) > 0 %}
+        <p><strong>Energy consumption:</strong> {{ estimate['local_energy_kwh'] }} kWh</p>
         {% endif %}
-        
-        {% if estimate.warning %}
-        <p style="color: var(--orange)"><strong>Warning:</strong> {{ estimate.warning }}</p>
+
+        {% if estimate.get('warning') %}
+        <p style="color: var(--orange)"><strong>Warning:</strong> {{ estimate['warning'] }}</p>
         {% endif %}
     </div>
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,6 +8,12 @@ from rune_ui.main import app
 client = TestClient(app)
 
 
+def test_healthz_returns_ok() -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_index_page() -> None:
     response = client.get("/")
     assert response.status_code == 200
@@ -23,19 +29,19 @@ def test_api_status_online(mock_health: AsyncMock) -> None:
 
 
 @patch("rune_ui.api_client.RuneApiClient.get_health", new_callable=AsyncMock)
-def test_api_status_degraded(mock_health: AsyncMock) -> None:
+def test_api_status_not_connected_bad_status(mock_health: AsyncMock) -> None:
     mock_health.return_value = {"status": "degraded"}
     response = client.get("/api/status")
     assert response.status_code == 200
-    assert "DEGRADED" in response.text
+    assert "NOT CONNECTED" in response.text
 
 
 @patch("rune_ui.api_client.RuneApiClient.get_health", new_callable=AsyncMock)
-def test_api_status_offline(mock_health: AsyncMock) -> None:
+def test_api_status_not_connected_exception(mock_health: AsyncMock) -> None:
     mock_health.side_effect = Exception("offline")
     response = client.get("/api/status")
     assert response.status_code == 200
-    assert "OFFLINE" in response.text
+    assert "NOT CONNECTED" in response.text
 
 
 def test_benchmarks_page() -> None:


### PR DESCRIPTION
## Summary

- Adds `/healthz` endpoint returning `{"status": "ok"}`
- Fixes estimation crash: dict bracket notation in Jinja2 template
- Fixes API status: shows NOT CONNECTED instead of DEGRADED when backend unavailable

Closes #46

## DoD Level

- [x] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation

## Acceptance Criteria Evidence

- 43 tests pass, 100% coverage
- docker-compose tested: healthz 200, estimation graceful error, status resilient

## Audit Checks

No triggers fired.

## Breaking Changes

None.