### PR TITLE
fix(deps): remediate CVE-2025-13836

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # RUNE UI Dockerfile (Zero NPM)
-FROM python:3.13-slim-bookworm
+FROM python:3.13.11-slim-bookworm
 
 # 1. Security: Create non-root user
 RUN groupadd -r rune && useradd -r -g rune -u 1000 rune
@@ -7,7 +7,8 @@ RUN groupadd -r rune && useradd -r -g rune -u 1000 rune
 # 2. Dependencies
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
 # 3. Application code
 COPY rune_ui/ rune_ui/


### PR DESCRIPTION
## Summary

Pin CPython base image to 3.13.11-slim-bookworm to remediate CVE-2025-13836 (HTTP client memory DoS, CVSS 7.5) and upgrade pip at build time to resolve GHSA-6vgw-5pg2-w6jp. This unblocks the SBOM-and-CVE-Policy CI gate that was preventing all PR merges.

Closes #56

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [x] Tested in **docker-compose mode** — `docker build` + `docker run` confirms container starts on 8080
- [ ] Tested in **kind (Kubernetes) mode** — deferred to CI (no kind cluster available locally)
- [x] Tested in **standalone CLI mode** — `pytest` 46/46 pass, 99.49% coverage
- [x] **Breaking change audit**: API versions, persistent data, cross-component contracts — no changes to API or data; only base image pin
- [x] **Dependency CVE audit** (if deps changed): `grype` scan of built image shows zero fixable CVEs above CVSS 7.0 threshold

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:dep python:3.13.11-slim-bookworm` | PASS | grype scan of `rune-ui:cve-fix` image: 0 fixable CVEs >= 7.0. CVE-2025-13836 absent from scan. |
| `cyber check:supply-chain` | PASS | Dockerfile change pins base image to specific patch version, reducing supply-chain risk from floating tags. |
| `legal check:dep python:3.13.11-slim-bookworm` | PASS | Same upstream Python PSF license (PSF-2.0), no license change. |

## Acceptance Criteria Evidence

- [x] CVE-2025-13836 absent from `grype rune-ui:cve-fix` output — confirmed via local scan
- [x] GHSA-6vgw-5pg2-w6jp (pip) absent from `grype rune-ui:cve-fix` output — confirmed via local scan
- [x] No fixable CVEs above CVSS 7.0 threshold remain — confirmed via `grype -o json` analysis
- [x] All 46 tests pass with 99.49% coverage (above 97% floor)

## Test Plan Evidence

- [x] `docker build --no-cache -t rune-ui:cve-fix .` succeeds with pinned base image
- [x] `grype rune-ui:cve-fix | grep CVE-2025-13836` returns empty (CVE resolved)
- [x] `python -m pytest --cov --cov-fail-under=97` passes (46/46, 99.49%)

## Breaking Changes

None. The only change is pinning the base image from a floating tag to a specific patch version and upgrading pip during build.

## Notes for Reviewer

The remaining CVEs in the grype scan are all either unfixable (won't fix in Debian bookworm) or Negligible severity. None are fixable above the 7.0 CVSS threshold. These should be tracked in the VEX register per existing policy.