### PR TITLE
fix: upgrade pip in Dockerfile (CVE-2026-1703)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN groupadd -r rune && useradd -r -g rune -u 1000 rune
 # 2. Dependencies
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
 
 # 3. Application code
 COPY rune_ui/ rune_ui/


### PR DESCRIPTION
## Summary

- fix: upgrade pip in Dockerfile (CVE-2026-1703)

Closes #58

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation

## Acceptance Criteria Evidence

- CI passes with fix applied

## Audit Checks

cyber check:supply-chain — PASS (security/CI config change only)

## Breaking Changes

None.