### PR TITLE
fix: add SPDX-License-Identifier headers to all Python files

### DIFF
--- a/rune_ui/api_client.py
+++ b/rune_ui/api_client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from typing import Any, Dict, Optional
 

--- a/rune_ui/main.py
+++ b/rune_ui/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import base64
 import hashlib

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import AsyncMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary
- Add `# SPDX-License-Identifier: Apache-2.0` to all Python source files
- Required for IEC 62443 ML4 legal compliance and REUSE specification

Closes #71

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure (header-only change, no runtime impact)
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] All .py files have SPDX header as first line
- [x] Tests pass with no regressions

## Audit Checks

No triggers fired — no dependencies, CI, or API changes.

## Breaking Changes

None.

## Test plan

- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)