### PR TITLE
Add print stylesheet for clean printed output

### DIFF
--- a/rune_ui/static/print.css
+++ b/rune_ui/static/print.css
@@ -1,0 +1,108 @@
+/* Print stylesheet for RUNE UI */
+@media print {
+    /* Hide non-essential UI elements */
+    nav,
+    .sidebar,
+    #theme-toggle,
+    .modal,
+    .overlay,
+    footer,
+    button {
+        display: none !important;
+    }
+
+    /* White background, black text */
+    body {
+        background-color: #fff !important;
+        color: #000 !important;
+        font-family: 'Courier New', Courier, monospace;
+        padding: 10px;
+    }
+
+    /* Override container grid to single column */
+    .container {
+        display: block !important;
+    }
+
+    /* Headings */
+    h1, h2, h3, h4, h5, h6 {
+        color: #000 !important;
+    }
+
+    /* Show link URLs after anchors */
+    a[href]::after {
+        content: " (" attr(href) ")";
+        font-size: 0.85em;
+        color: #333;
+    }
+
+    a {
+        color: #000 !important;
+        text-decoration: underline;
+    }
+
+    /* Code blocks */
+    code, pre {
+        background: #f5f5f5 !important;
+        color: #000 !important;
+        border: 1px solid #ccc;
+        overflow: visible !important;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        font-family: 'Courier New', Courier, monospace;
+    }
+
+    /* Tables */
+    table {
+        border-collapse: collapse;
+        width: 100%;
+    }
+
+    th, td {
+        border: 1px solid #000 !important;
+        padding: 6px;
+        color: #000 !important;
+    }
+
+    /* Alternating row colors in grayscale */
+    tr:nth-child(even) {
+        background-color: #f0f0f0 !important;
+    }
+
+    tr:nth-child(odd) {
+        background-color: #fff !important;
+    }
+
+    th {
+        background-color: #ddd !important;
+    }
+
+    /* Cards: remove dark backgrounds, use borders */
+    .card {
+        background: #fff !important;
+        border: 1px solid #999 !important;
+        color: #000 !important;
+    }
+
+    /* Page break rules */
+    .card, pre, table {
+        page-break-inside: avoid;
+    }
+
+    /* Header styling for print */
+    header {
+        border-bottom: 2px solid #000;
+    }
+
+    /* Input fields */
+    input, select, textarea {
+        border: 1px solid #000 !important;
+        background: #fff !important;
+        color: #000 !important;
+    }
+
+    /* Labels */
+    label {
+        color: #000 !important;
+    }
+}

--- a/rune_ui/templates/base.html
+++ b/rune_ui/templates/base.html
@@ -7,6 +7,7 @@
     <script src="https://unpkg.com/htmx.org@2.0.0"></script>
     <link rel="stylesheet" href="/static/solarized.css">
     <link rel="stylesheet" href="/static/solarized-light.css">
+    <link rel="stylesheet" href="/static/print.css">
 </head>
 <body>
     <header>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -628,3 +628,18 @@ def test_solarized_light_css_serves_successfully() -> None:
     response = client.get("/static/solarized-light.css")
     assert response.status_code == 200
     assert "data-theme" in response.text
+# ── Issue #34: print stylesheet ─────────────────────────────────────────────
+
+
+def test_index_contains_print_css_link() -> None:
+    """GET / must include a link to print.css."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "/static/print.css" in response.text
+
+
+def test_print_css_serves_successfully() -> None:
+    """GET /static/print.css must return 200."""
+    response = client.get("/static/print.css")
+    assert response.status_code == 200
+    assert "@media print" in response.text


### PR DESCRIPTION
## Summary
- Add `print.css` with `@media print` rules for clean printed output
- Hide nav, sidebar, theme toggle, modals, footer, and buttons when printing
- White background, black text, link URLs shown after anchors
- Tables print with borders and grayscale alternating rows
- Cards use borders instead of dark backgrounds; page-break-inside avoided for cards, pre, tables
- Add `<link>` tag to `base.html` head

Closes #34

## DoD Level
- [x] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] GET / response HTML contains `/static/print.css` link tag
- [x] `/static/print.css` serves with 200 status and contains `@media print`
- [x] Print CSS hides nav, .sidebar, #theme-toggle, .modal, .overlay, footer, button
- [x] White background (#fff) and black text (#000) applied to body
- [x] Link URLs shown via `a[href]::after { content: " (" attr(href) ")"; }`
- [x] Tables have borders, grayscale alternating rows
- [x] Cards: white background, border instead of dark bg
- [x] Page break rules: `page-break-inside: avoid` on .card, pre, table
- [x] All 48 tests pass, 100% coverage maintained

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] `pytest` — 48 tests pass, 100% coverage (was 46 tests, 100%)
- [x] `test_index_contains_print_css_link` — verifies print.css link in HTML
- [x] `test_print_css_serves_successfully` — verifies CSS file serves with 200