### PR TITLE
build(deps): bump python base image from 3.13-slim-bookworm to 3.14-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # RUNE UI Dockerfile (Zero NPM)
-FROM python:3.13-slim-bookworm
+FROM python:3.14-slim-bookworm
 
 # 1. Security: Create non-root user
 RUN groupadd -r rune && useradd -r -g rune -u 1000 rune


### PR DESCRIPTION
## Summary
- Bump Python base image from 3.13-slim-bookworm to 3.14-slim-bookworm in Dockerfile

Closes lpasquali/rune-ui#77

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] Dockerfile base image updated to python:3.14-slim-bookworm

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] Dockerfile updated with new base image