### PR TITLE
fix(ci): resolve duplicate --cov flags (coverage job + merge gate)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -67,7 +67,7 @@ jobs:
     uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@14fe4ea7bd322f1e2c8ec59fc2d733527e905d2e # main
     with:
       needs-json: ${{ toJson(needs) }}
-      merge-gate-excludes: "python,integration,container,security" # Force pass for now to unblock
+      merge-gate-excludes: "integration,container,security"
 
   merge-gate:
     name: Merge Gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ rune_ui = ["templates/**/*.html", "static/**/*"]
 include = ["rune_ui*"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=rune_ui --cov-report=term-missing --cov-fail-under=97"
+# Coverage runs in CI only (rune-ci python-quality.yml); local: add --cov=rune_ui --cov-fail-under=97
 testpaths = ["tests"]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

**Option A:** Removed `--cov` / `--cov-report` / `--cov-fail-under` from `[tool.pytest.ini_options]` in `pyproject.toml` so CI’s `rune-ci` `python-quality.yml` is the only injector (fixes duplicate `--cov=rune_ui` / pytest exit 4). Removed `python` from `merge-gate-excludes` so **RuneGate/Coverage/Python** gates merges again.

Closes #108
Epic: n/a

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

*Skipped (Level 2).*

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

*Skipped (Level 2).*

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(none)* | — | CI workflows unchanged except merge-gate string; `rune-ci` pin unchanged |

## Acceptance Criteria Evidence

- [x] **Single source for `--cov`:** `pyproject.toml` no longer adds coverage `addopts`; CI injects coverage only — evidence: diff + green `python / RuneGate/Coverage/Python` on this PR.
- [x] **`python` job passes on PR:** `python / RuneGate/Coverage/Python` SUCCESS on this branch.
- [x] **`python` removed from merge-gate-excludes:** `quality-gates.yml` diff; merge gate will fail if python job fails.
- [x] **Coverage ≥ 97%:** CI coverage job enforces threshold (same as before duplicate was removed).

## Test Plan Evidence

- [x] CI: `python / RuneGate/Coverage/Python` green on this PR (workflow run).
- [x] Local: `pytest` without default coverage; with coverage use `pytest --cov=rune_ui --cov-report=term-missing --cov-fail-under=97` (documented in `pyproject.toml` comment).

## Breaking Changes

None.

## Notes for Reviewer

None.
