### PR TITLE
fix: Use Python 3.12 for integration smoke tests

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -50,6 +50,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     with:
       path-filter: ".*"
+      python-version: "3.12"
 
   container:
     needs: [changes, security]


### PR DESCRIPTION
Integration smoke test requires Python 3.12+ but was defaulting to 3.11. Pass python-version parameter to integration workflow.