### PR TITLE
fix: Disable smoke-install test hardcoded to Python 3.11

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -51,6 +51,7 @@ jobs:
     with:
       path-filter: ".*"
       python-version: "3.12"
+      smoke-install-enabled: false
 
   container:
     needs: [changes, security]


### PR DESCRIPTION
The rune-ci smoke-install job hardcodes Python 3.11 and doesn't respect the python-version parameter. Disable it until rune-ci is updated to support Python 3.12+.