### PR TITLE
chore(ci): adopt rune-ci@eae1383 merge gate policy

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -32,31 +32,31 @@ jobs:
           echo "docker=true" >> "$GITHUB_OUTPUT"
 
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     secrets: inherit
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       source-dirs: "rune_ui"
-      test-deps: "pytest pytest-xdist pytest-cov respx"
+      test-deps: "pytest pytest-cov pytest-xdist respx"
       path-filter: '.*'
       allowed-license-exceptions: "bashlex,borb"
     secrets: inherit
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     needs: [changes, python]
     if: needs.changes.outputs.python == 'true'
     with:
       path-filter: ".*"
-      python-version: "3.12"
-      smoke-install-enabled: false
+      ollama-enabled: false
+      smoke-python-version: "3.12"
 
   container:
     needs: [changes, security]
     if: needs.changes.outputs.docker == 'true'
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       image-name: "rune-ui"
       push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -64,15 +64,6 @@ jobs:
   compliance:
     needs: [security, python, integration, container]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       needs-json: ${{ toJson(needs) }}
-      merge-gate-excludes: "python,integration,container,security" # Force pass for now to unblock
-
-  merge-gate:
-    name: Merge Gate
-    needs: [compliance]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Merge Gate Satisfied"

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -32,11 +32,11 @@ jobs:
           echo "docker=true" >> "$GITHUB_OUTPUT"
 
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     secrets: inherit
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       source-dirs: "rune_ui"
       test-deps: "pytest pytest-cov pytest-xdist respx"
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     needs: [changes, python]
     if: needs.changes.outputs.python == 'true'
     with:
@@ -56,7 +56,7 @@ jobs:
   container:
     needs: [changes, security]
     if: needs.changes.outputs.docker == 'true'
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       image-name: "rune-ui"
       push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -64,6 +64,6 @@ jobs:
   compliance:
     needs: [security, python, integration, container]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       needs-json: ${{ toJson(needs) }}


### PR DESCRIPTION
## Summary

Pins `lpasquali/rune-ci` reusable workflows to `eae13830420fe3b9d558edb081c01c90bdc01d03` and removes the redundant top-level `merge-gate` job so the **Merge Gate** enforced inside `pr-compliance` is authoritative (SoD / epic https://github.com/lpasquali/rune-ci/issues/25).

Fixes #128

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes (via Quality Gates on this PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects (workflow-only change)

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| (n/a) | PASS | No audit triggers per SYSTEM_PROMPT |

## Acceptance Criteria Evidence

- [x] Workflow pins and merge-gate wiring match SoD follow-up issue — evidence: this PR diff and green Quality Gates.

## Test Plan Evidence

- [x] CI-only change; validated by repository Quality Gates workflow on this PR.

## Breaking Changes

None.

## Notes for Reviewer

Part of SoD remediation after unreviewed `rune-ci` `main` push (retro https://github.com/lpasquali/rune-ci/issues/26).
