### PR TITLE
ci: enable Ollama integration in quality gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -50,7 +50,6 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     with:
       path-filter: ".*"
-      ollama-enabled: false
       smoke-python-version: "3.12"
 
   container:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ include = ["rune_ui*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: live Ollama (OLLAMA_TEST_URL / OLLAMA_TEST_MODEL from CI)",
+]
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,44 @@
+"""Live checks against Ollama for rune-ui CI (rune-ci python-integration workflow).
+
+Skipped locally unless OLLAMA_TEST_URL is set. In GitHub Actions the
+RuneGate/Ollama-Integration job sets OLLAMA_TEST_URL and OLLAMA_TEST_MODEL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_OLLAMA_URL = os.environ.get("OLLAMA_TEST_URL", "").rstrip("/")
+_OLLAMA_MODEL = os.environ.get("OLLAMA_TEST_MODEL", "tinyllama")
+
+
+@pytest.fixture(scope="module")
+def ollama_url() -> str:
+    if not _OLLAMA_URL:
+        pytest.skip("OLLAMA_TEST_URL not set — skipping live Ollama integration tests")
+    return _OLLAMA_URL
+
+
+def test_ollama_api_tags_lists_pulled_model(ollama_url: str) -> None:
+    """Ensure the CI-pulled model is visible (validates Ollama is up and pull succeeded)."""
+    req = urllib.request.Request(f"{ollama_url}/api/tags", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            assert resp.status == 200
+            data = json.load(resp)
+    except urllib.error.URLError as exc:
+        pytest.fail(f"Ollama /api/tags unreachable: {exc}")
+
+    models = data.get("models") or []
+    names = [str(m.get("name", "")) for m in models]
+    base = _OLLAMA_MODEL.split(":")[0].lower()
+    assert any(base in n.lower() for n in names), (
+        f"expected model containing {base!r} in Ollama tags; got {names!r}"
+    )


### PR DESCRIPTION
## Summary

Turn on the shared `python-integration` Ollama job for rune-ui (default `ollama-enabled: true`) and add a minimal live `/api/tags` test so CI has `tests/test_ollama_integration.py` as required by the reusable workflow.

## Definition of Done

- [ ] **Level 1**
- [x] **Level 2**
- [ ] **Level 3**

## Acceptance Criteria Evidence

- `quality-gates.yml` no longer sets `ollama-enabled: false`.
- `tests/test_ollama_integration.py` validates the pulled model appears in Ollama tags when `OLLAMA_TEST_URL` is set.
- `integration` pytest marker registered in `pyproject.toml`.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)