### PR TITLE
fix(docker): multi-stage image (rune-ci canonical pattern)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,30 @@
-# RUNE UI Dockerfile (Zero NPM)
-FROM python:3.14-slim-bookworm
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-stage image — must match lpasquali/rune-ci/docker/rune-ui-slim.Dockerfile
+# (canonical). Change the rune-ci copy first, then mirror here.
 
-# 1. Security: Create non-root user
-RUN groupadd -r rune && useradd -r -g rune -u 1000 rune
+FROM python:3.14-slim AS builder
 
-# 2. Dependencies
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir pip==26.0 \
- && pip install --no-cache-dir -r requirements.txt
-
-# 3. Application code
+COPY pyproject.toml README.md LICENSE ./
 COPY rune_ui/ rune_ui/
 
-# 4. Security: Hardening
-RUN chown -R rune:rune /app
-USER 1000
+RUN pip install --no-cache-dir pip==26.0 \
+ && pip install --no-cache-dir --prefer-binary .
 
-# 5. Runtime
+FROM python:3.14-slim
+
+LABEL org.opencontainers.image.source="https://github.com/lpasquali/rune-ui"
+LABEL org.opencontainers.image.description="RUNE UI — FastAPI web UI for the RUNE ecosystem"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN groupadd -r rune && useradd -r -g rune -u 1000 -d /app -s /sbin/nologin rune
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+
+USER rune
+
 EXPOSE 8080
 ENTRYPOINT ["python", "-m", "uvicorn", "rune_ui.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary

Switch `Dockerfile` to **multi-stage** (`python:3.14-slim` builder + slim runtime) like `rune-audit`: install with `pip install .` in builder, copy only `/usr/local/lib/python3.14/site-packages` into the final image, add OCI labels, run as non-root `rune`.

Body must match `lpasquali/rune-ci/docker/rune-ui-slim.Dockerfile` (see comment in `Dockerfile`).

## Definition of Done

- [x] **Level 2**
- [ ] **Level 1**
- [ ] **Level 3**

## Acceptance Criteria Evidence

- `docker build` succeeds locally.
- Uses shared `container-build.yml` unchanged (already centralized on rune-ci).

## Audit Checks

No triggers fired.

## Breaking Changes

None. Base image moves from `python:3.14-slim-bookworm` to `python:3.14-slim` (Debian trixie series); behavior should be equivalent for this stack.

## Related

Requires / pairs with `rune-ci` PR adding `docker/rune-ui-slim.Dockerfile` + structure tests.

Made with [Cursor](https://cursor.com)