### PR TITLE
chore(ci): pin lpasquali/rune-ci reusable workflows to 9f939b2

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -32,11 +32,11 @@ jobs:
           echo "docker=true" >> "$GITHUB_OUTPUT"
 
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     secrets: inherit
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       source-dirs: "rune_ui"
       test-deps: "pytest pytest-cov pytest-xdist respx"
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     needs: [changes, python]
     if: needs.changes.outputs.python == 'true'
     with:
@@ -55,7 +55,7 @@ jobs:
   container:
     needs: [changes, security]
     if: needs.changes.outputs.docker == 'true'
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       image-name: "rune-ui"
       push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -63,6 +63,6 @@ jobs:
   compliance:
     needs: [security, python, integration, container]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       needs-json: ${{ toJson(needs) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/release.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/release.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary

Pin every `lpasquali/rune-ci/.github/workflows/...` `workflow_call` to **`9f939b2c28317b6f55c1913c6a6485bd91e1bda5`** (current `rune-ci` `main`).

## Changes

- Replace prior SHAs: `40149ab…`, `b242495…`, `95f0b3…`, `ac0bd4…` (charts helm-release) where present.
- Replace `@main` branch pins on reusable workflow `uses:` with the same full SHA.

## Definition of Done

- [x] **Level 1**

## Acceptance Criteria Evidence

- All `uses: lpasquali/rune-ci/.github/workflows/…@` references in this repo use the new SHA; no `@main` for those paths.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)